### PR TITLE
Violation of Java Equality and Hashing Contract in UnsupportedElementFactory

### DIFF
--- a/common/src/main/java/com/google/auto/common/BasicAnnotationProcessor.java
+++ b/common/src/main/java/com/google/auto/common/BasicAnnotationProcessor.java
@@ -634,6 +634,17 @@ public abstract class BasicAnnotationProcessor extends AbstractProcessor {
       super(element);
       this.element = element;
     }
+      @Override //hiba
+      public boolean equals(Object obj) {
+          if (this == obj) return true;
+          if (!(obj instanceof UnsupportedElementFactory)) return false;
+          UnsupportedElementFactory other = (UnsupportedElementFactory) obj;
+          return Objects.equals(this.element, other.element);
+}
+      @Override
+      public int hashCode() {
+          return Objects.hash(element);
+      }
 
     @Override
     Element getElement(Elements elementUtils) {


### PR DESCRIPTION
**Describe the pull request**

This PR addresses a technical debt identified by SonarQube rule java:S2160, which flagged a violation of Java’s equality and hashing contract. The issue was caused by the UnsupportedElementFactory class not overriding the equals() and hashCode() methods.

To resolve this, the methods have been implemented to ensure consistent and logical equality comparisons between instances. This aligns with Java best practices and prevents incorrect behavior when objects are stored in hash-based collections such as HashMap or HashSet.

The path of file having the issue:
common/src/main/java/com/google/auto/common/ElementFactory.java

Link to the issue

The link to the issue: [#9](https://github.com/amirchappalwala/group2-SCM-Fall25/issues/9)