### PR TITLE
Unused Import Removed from AnnotationMirrorsTest.java

### DIFF
--- a/common/src/test/java/com/google/auto/common/AnnotationMirrorsTest.java
+++ b/common/src/test/java/com/google/auto/common/AnnotationMirrorsTest.java
@@ -18,7 +18,6 @@ package com.google.auto.common;
 import static com.google.auto.common.AnnotationMirrorsTest.SimpleEnum.BLAH;
 import static com.google.auto.common.AnnotationMirrorsTest.SimpleEnum.FOO;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.truth.Truth.assertThat;
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static org.junit.Assert.fail;
 


### PR DESCRIPTION
This pull request resolves the issue of an unused import within the file AnnotationMirrorsTest.java at the path: common/src/test/java/com/google/auto/common/AnnotationMirrorsTest.java