### PR TITLE
Unused Import Removed from AnnotationMirrorsTest.java

### DIFF
--- a/common/src/test/java/com/google/auto/common/AnnotationMirrorsTest.java
+++ b/common/src/test/java/com/google/auto/common/AnnotationMirrorsTest.java
@@ -19,7 +19,6 @@ import static com.google.auto.common.AnnotationMirrorsTest.SimpleEnum.BLAH;
 import static com.google.auto.common.AnnotationMirrorsTest.SimpleEnum.FOO;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.testing.compile.CompilationSubject.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableSet;


### PR DESCRIPTION
This pull requests addresses the problem of an unused import in the file AnnotationmirrorsTest.java at the path: common/src/test/java/com/google/auto/common/AnnotationMirrorsTest.java