### PR TITLE
Fix: Resolve Finalizer attack vulnerability in KotlinMetadata$KotlinClassHeader

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/KotlinMetadata.java
+++ b/value/src/main/java/com/google/auto/value/processor/KotlinMetadata.java
@@ -99,7 +99,7 @@ final class KotlinMetadata {
     ImmutableMap<ImmutableSet<String>, ExecutableElement> paramNamesToConstructor =
         ImmutableMap.copyOf(map);
     KotlinClassHeader header =
-        new KotlinClassHeader(
+        KotlinClassHeader.create(
             (Integer) annotationValues.get("k").getValue(),
             intArrayValue(annotationValues.get("mv")),
             stringArrayValue(annotationValues.get("d1")),
@@ -164,13 +164,23 @@ final class KotlinMetadata {
   // allows us to write client code that is essentially the same as if we were using the real API.
   // Otherwise the logic would be obscured by all the reflective calls.
 
-  private static class KotlinClassHeader {
+  private static final class KotlinClassHeader {
     final Object /* KotlinClassHeader */ wrapped;
 
-    KotlinClassHeader(
+    private KotlinClassHeader(Object wrapped) {
+      // Private constructor ensures complete initialization before object is exposed
+      if (wrapped == null) {
+        throw new IllegalArgumentException("wrapped object cannot be null");
+      }
+      this.wrapped = wrapped;
+    }
+
+    static KotlinClassHeader create(
         Integer k, int[] mv, String[] d1, String[] d2, String xs, String pn, Integer xi)
         throws ReflectiveOperationException {
-      this.wrapped = NEW_KOTLIN_CLASS_HEADER.newInstance(k, mv, d1, d2, xs, pn, xi);
+      // Static factory method ensures the object is fully initialized before returning
+      Object wrappedInstance = NEW_KOTLIN_CLASS_HEADER.newInstance(k, mv, d1, d2, xs, pn, xi);
+      return new KotlinClassHeader(wrappedInstance);
     }
   }
 


### PR DESCRIPTION

Fixed a security vulnerability identified by SpotBugs where exceptions thrown
in the KotlinClassHeader constructor could leave the object partially
initialized and vulnerable to Finalizer attacks.

Changes:
- Made KotlinClassHeader constructor private to prevent direct instantiation
- Added static factory method create() that ensures complete initialization
- Added null check validation in private constructor
- Updated call site to use new static factory method instead of constructor
- Made class explicitly final to prevent subclassing

This fix ensures that if an exception occurs during object creation, no
partially initialized object can be exposed to potential finalizer attacks.

Security Issue: CN_IDIOM_NO_SUPER_CALL
Impact: Prevents potential security vulnerability in Kotlin metadata processing
